### PR TITLE
Priority Scheduler - 기본 셋팅

### DIFF
--- a/threads/thread.c
+++ b/threads/thread.c
@@ -31,6 +31,9 @@ static struct list ready_list;
 // busy waiting 방식 대신 sleep / wake up 방식으로 구현하기 위해 sleep list 생성
 static struct list sleep_list;
 
+// priority 조정을 위한 wait list
+static struct list wait_list;
+
 /* Idle thread. */
 static struct thread *idle_thread;
 
@@ -142,6 +145,7 @@ void thread_init(void)
 	list_init(&ready_list);
 	list_init(&destruction_req);
 	list_init(&sleep_list);
+	list_init(&wait_list);
 
 	/* Set up a thread structure for the running thread. */
 	initial_thread = running_thread();
@@ -212,33 +216,41 @@ void thread_print_stats(void)
 tid_t thread_create(const char *name, int priority,
 					thread_func *function, void *aux)
 {
-	struct thread *t;
+	struct thread *new_thread, *curr_thread;
 	tid_t tid;
 
 	ASSERT(function != NULL);
 
 	/* Allocate thread. */
-	t = palloc_get_page(PAL_ZERO);
-	if (t == NULL)
+	new_thread = palloc_get_page(PAL_ZERO);
+	if (new_thread == NULL)
 		return TID_ERROR;
 
 	/* Initialize thread. */
-	init_thread(t, name, priority);
-	tid = t->tid = allocate_tid();
+	init_thread(new_thread, name, priority);
+	tid = new_thread->tid = allocate_tid();
 
 	/* Call the kernel_thread if it scheduled.
 	 * Note) rdi is 1st argument, and rsi is 2nd argument. */
-	t->tf.rip = (uintptr_t)kernel_thread;
-	t->tf.R.rdi = (uint64_t)function;
-	t->tf.R.rsi = (uint64_t)aux;
-	t->tf.ds = SEL_KDSEG;
-	t->tf.es = SEL_KDSEG;
-	t->tf.ss = SEL_KDSEG;
-	t->tf.cs = SEL_KCSEG;
-	t->tf.eflags = FLAG_IF;
+	new_thread->tf.rip = (uintptr_t)kernel_thread;
+	new_thread->tf.R.rdi = (uint64_t)function;
+	new_thread->tf.R.rsi = (uint64_t)aux;
+	new_thread->tf.ds = SEL_KDSEG;
+	new_thread->tf.es = SEL_KDSEG;
+	new_thread->tf.ss = SEL_KDSEG;
+	new_thread->tf.cs = SEL_KCSEG;
+	new_thread->tf.eflags = FLAG_IF;
 
-	/* Add to run queue. */
-	thread_unblock(t);
+	curr_thread = thread_current();
+
+	/* Add new_thread to ready_list */
+	thread_unblock(new_thread);
+
+	if (new_thread->priority > curr_thread->priority)
+	{
+		// Insert curr_thread to ready_list
+		thread_yield();
+	}
 
 	return tid;
 }
@@ -404,7 +416,16 @@ void wake_up(int64_t now_ticks)
 /* Sets the current thread's priority to NEW_PRIORITY. */
 void thread_set_priority(int new_priority)
 {
-	thread_current()->priority = new_priority;
+	struct thread *curr_thread, *ready_thread;
+	curr_thread = thread_current();
+	ready_thread = list_entry(list_front(&ready_list), struct thread, elem);
+	curr_thread->priority = new_priority;
+
+	if (ready_thread->priority > curr_thread->priority)
+	{
+		// Insert curr_thread to ready_list
+		thread_yield();
+	}
 }
 
 /* Returns the current thread's priority. */


### PR DESCRIPTION
**1. 수정 결과**
    - priority-change 테스트 통과

**2. 수정 사항**
    - thread_create() 에서 새로운 thread와 running중인 current thread 우선순위 확인하여 순서 바꿔주기
    - thread_unblock(), thread_yield()에서 thread insert할때 ready_list 우선순위 기반으로 reorder하기
    - thread_set_priority() 진행시 running 중인 current thread의 바뀐 우선순위와, ready list의 가장 우선순위 높은 thread의 우선순위 비교 후 실행 순서 결정해주기